### PR TITLE
Feat/unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ im-user
 # decrypted secret files
 *.dec
 *.pem
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ test: clean
 	docker compose run --no-deps test
 	$(clean-cmd)
 
+test-coverage: clean
+	docker compose up -d database redis
+	docker compose run --no-deps test-coverage
+	$(clean-cmd)
+
 dev-test: clean
 	docker compose up -d database redis
 	docker compose run --no-deps dev-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     <<: *common-dev-test
     command: /bin/sh -c 'go test -v ./...'
 
+  test-coverage:
+    <<: *common-dev-test
+    command: /bin/sh -c 'go test -coverprofile=./coverage.out -v ./... && go tool cover -html=./coverage.out -o ./coverage.html'
+
   dev-test:
     <<: *common-dev-test
     command: reflex -r "Dockerfile|\.go|\.yml$$" -s -- sh -c "go test -v ./..."

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	go.mongodb.org/mongo-driver v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/middleware/authentication_test.go
+++ b/internal/middleware/authentication_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dhis2-sre/im-user/pkg/model"
+	"github.com/dhis2-sre/im-user/pkg/token"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
+)
+
+func TestAuthenticationMiddleware_BasicAuthentication_Happy(t *testing.T) {
+	id := uint(1)
+	email := "someone@something.org"
+	password := "passwordpasswordpasswordpassword"
+
+	userService := &mockUserService{}
+	userService.On("SignIn", email, password).Return(&model.User{
+		Model:    gorm.Model{ID: id},
+		Email:    email,
+		Password: password,
+	}, nil)
+
+	tokenService := &mockTokenService{}
+	m := AuthenticationMiddleware{
+		userService:  userService,
+		tokenService: tokenService,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/whatever", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.SetBasicAuth(email, password)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	_, exists := c.Get("user")
+	assert.False(t, exists)
+
+	m.BasicAuthentication(c)
+
+	value, exists := c.Get("user")
+	assert.True(t, exists)
+	user, ok := value.(*model.User)
+	assert.True(t, ok)
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, password, user.Password)
+
+	userService.AssertExpectations(t)
+	tokenService.AssertExpectations(t)
+}
+
+func TestAuthenticationMiddleware_TokenAuthentication(t *testing.T) {
+}
+
+type mockUserService struct{ mock.Mock }
+
+func (s *mockUserService) FindOrCreate(email string, password string) (*model.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *mockUserService) SignUp(email string, password string) (*model.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *mockUserService) SignIn(email string, password string) (*model.User, error) {
+	called := s.Called(email, password)
+	return called.Get(0).(*model.User), nil
+}
+
+func (s *mockUserService) FindById(id uint) (*model.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+type mockTokenService struct{ mock.Mock }
+
+func (t *mockTokenService) ValidateAccessToken(tokenString string) (*model.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t *mockTokenService) GetTokens(user *model.User, previousTokenId string) (*token.Tokens, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t *mockTokenService) ValidateRefreshToken(tokenString string) (*token.RefreshTokenData, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t *mockTokenService) SignOut(userId uint) error {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -91,7 +91,7 @@ func TestHandler_SignIn(t *testing.T) {
 		Return(&model.User{
 			Model:    gorm.Model{ID: id},
 			Email:    email,
-			Password: password, // TODO: Should be hashed
+			Password: password,
 		})
 	tokenService := &mockTokenService{}
 	tokenService.
@@ -158,7 +158,7 @@ func TestHandler_Me(t *testing.T) {
 		Return(&model.User{
 			Model:    gorm.Model{ID: id},
 			Email:    email,
-			Password: password, // TODO: Should be hashed
+			Password: password,
 		}, nil)
 
 	r := gin.Default()

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -1,0 +1,233 @@
+package user
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dhis2-sre/im-user/internal/middleware"
+	"github.com/dhis2-sre/im-user/pkg/config"
+	"github.com/dhis2-sre/im-user/pkg/model"
+	"github.com/dhis2-sre/im-user/pkg/token"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
+)
+
+func TestHandler_SignUp(t *testing.T) {
+	id := uint(1)
+	email := "someone@something.org"
+	password := "passwordpasswordpasswordpassword"
+
+	c, err := config.New()
+	assert.NoError(t, err)
+
+	userService := &mockUserService{}
+	userService.
+		On("SignUp", email, password).
+		Return(&model.User{Model: gorm.Model{ID: id}, Email: email, Password: password})
+	tokenService := &mockTokenService{}
+
+	handler := NewHandler(c, userService, tokenService)
+
+	request := SignUpRequest{
+		Email:    email,
+		Password: password,
+	}
+	req := newRequest(t, request)
+
+	r := gin.Default()
+	r.POST("/users", handler.SignUp)
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, req)
+
+	actual := recorder.Code
+	assert.Equal(t, http.StatusCreated, actual)
+
+	body := recorder.Body
+	user := &model.User{}
+	err = json.Unmarshal(body.Bytes(), user)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, "", user.Password)
+
+	userService.AssertExpectations(t)
+	tokenService.AssertExpectations(t)
+}
+
+func newRequest(t *testing.T, request any) *http.Request {
+	body, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
+	assert.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+
+	return req
+}
+
+func TestHandler_SignIn(t *testing.T) {
+	id := uint(1)
+	email := "someone@something.org"
+	password := "passwordpasswordpasswordpassword"
+
+	accessToken := "access token"
+	tokenType := ""
+	refreshToken := ""
+	expiresIn := uint(0)
+
+	c, err := config.New()
+	assert.NoError(t, err)
+
+	userService := &mockUserService{}
+	userService.
+		On("SignIn", email, password).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: password, // TODO: Should be hashed
+		})
+	tokenService := &mockTokenService{}
+	tokenService.
+		On("GetTokens", mock.AnythingOfType("*model.User"), mock.AnythingOfType("string")).
+		Return(&token.Tokens{
+			AccessToken:  accessToken,
+			TokenType:    tokenType,
+			RefreshToken: refreshToken,
+			ExpiresIn:    expiresIn,
+		}, nil)
+
+	r := gin.Default()
+	authentication := middleware.NewAuthentication(userService, tokenService)
+	r.Use(authentication.BasicAuthentication)
+	handler := NewHandler(c, userService, tokenService)
+	r.POST("/tokens", handler.SignIn)
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequest(http.MethodPost, "/tokens", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.SetBasicAuth(email, password)
+
+	r.ServeHTTP(recorder, req)
+
+	actual := recorder.Code
+	assert.Equal(t, http.StatusCreated, actual)
+
+	body := recorder.Body
+	tokens := &token.Tokens{}
+	err = json.Unmarshal(body.Bytes(), tokens)
+	assert.NoError(t, err)
+
+	assert.Equal(t, accessToken, tokens.AccessToken)
+	assert.Equal(t, tokenType, tokens.TokenType)
+	assert.Equal(t, refreshToken, tokens.RefreshToken)
+	assert.Equal(t, expiresIn, tokens.ExpiresIn)
+
+	userService.AssertExpectations(t)
+	tokenService.AssertExpectations(t)
+}
+
+func TestHandler_Me(t *testing.T) {
+	bearerToken := "token"
+	id := uint(1)
+	email := "someone@something.org"
+	password := "passwordpasswordpasswordpassword"
+
+	c, err := config.New()
+	assert.NoError(t, err)
+
+	userService := &mockUserService{}
+	userService.
+		On("FindById", id).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: password,
+		}, nil)
+	tokenService := &mockTokenService{}
+	tokenService.
+		On("ValidateAccessToken", bearerToken).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: password, // TODO: Should be hashed
+		}, nil)
+
+	r := gin.Default()
+	authentication := middleware.NewAuthentication(userService, tokenService)
+	r.Use(authentication.TokenAuthentication)
+	handler := NewHandler(c, userService, tokenService)
+	r.GET("/me", handler.Me)
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequest(http.MethodGet, "/me", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Set("Authorization", bearerToken)
+	r.ServeHTTP(recorder, req)
+
+	body := recorder.Body
+	user := &model.User{}
+	err = json.Unmarshal(body.Bytes(), user)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, "", user.Password)
+
+	userService.AssertExpectations(t)
+	tokenService.AssertExpectations(t)
+}
+
+type mockUserService struct{ mock.Mock }
+
+func (s *mockUserService) FindOrCreate(email string, password string) (*model.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *mockUserService) SignUp(email string, password string) (*model.User, error) {
+	called := s.Called(email, password)
+	return called.Get(0).(*model.User), nil
+}
+
+func (s *mockUserService) SignIn(email string, password string) (*model.User, error) {
+	called := s.Called(email, password)
+	return called.Get(0).(*model.User), nil
+}
+
+func (s *mockUserService) FindById(id uint) (*model.User, error) {
+	called := s.Called(id)
+	return called.Get(0).(*model.User), nil
+}
+
+type mockTokenService struct{ mock.Mock }
+
+func (t *mockTokenService) ValidateAccessToken(tokenString string) (*model.User, error) {
+	called := t.Called(tokenString)
+	return called.Get(0).(*model.User), nil
+}
+
+func (t *mockTokenService) GetTokens(user *model.User, previousTokenId string) (*token.Tokens, error) {
+	called := t.Called(user, previousTokenId)
+	return called.Get(0).(*token.Tokens), nil
+}
+
+func (t *mockTokenService) ValidateRefreshToken(tokenString string) (*token.RefreshTokenData, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t *mockTokenService) SignOut(userId uint) error {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -20,7 +20,7 @@ type userRepository interface {
 	create(user *model.User) error
 	findByEmail(email string) (*model.User, error)
 	findById(id uint) (*model.User, error)
-	findOrCreate(email *model.User) (*model.User, error)
+	findOrCreate(user *model.User) (*model.User, error)
 }
 
 type service struct {

--- a/pkg/user/service_test.go
+++ b/pkg/user/service_test.go
@@ -1,0 +1,235 @@
+package user
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dhis2-sre/im-user/internal/errdef"
+	"github.com/dhis2-sre/im-user/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func Test_service_SignUp_Happy(t *testing.T) {
+	email := "email"
+	password := "password"
+
+	createUserRepository := &mockUserRepository{}
+	createUserRepository.
+		On("create", mock.AnythingOfType("*model.User")).
+		Return(nil, nil)
+
+	s := service{repository: createUserRepository}
+
+	user, err := s.SignUp(email, password)
+	require.NoError(t, err)
+
+	createUserRepository.AssertExpectations(t)
+
+	assert.Equal(t, email, user.Email)
+	assert.NotEmpty(t, user.Password)
+}
+
+func Test_service_SignUp_UserExists(t *testing.T) {
+	email := "email"
+	password := "password"
+	errorMessage := "duplicated user"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("create", mock.AnythingOfType("*model.User")).
+		Return(errors.New(errorMessage))
+
+	s := service{repository: repository}
+
+	_, err := s.SignUp(email, password)
+	require.Error(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, errorMessage, err.Error())
+}
+
+func Test_service_SignIn_Happy(t *testing.T) {
+	id := uint(1)
+	email := "email"
+	password := "passwordpasswordpasswordpassword"
+	hashedPassword := "c55d1333f8567be7bfcc00fcae72720d30ae465cf62fb31c33303b707a18c2ca.f053011abe74ca660c2d98de8747ad0d6a6f401ccfb513e68127b1a46b42ed19"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findByEmail", email).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: hashedPassword,
+		}, nil)
+
+	s := service{repository: repository}
+
+	user, err := s.SignIn(email, password)
+	require.NoError(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, hashedPassword, user.Password)
+}
+
+func Test_service_SignIn_BadCredentials(t *testing.T) {
+	email := "email"
+	password := "password"
+	hashedPassword := "c55d1333f8567be7bfcc00fcae72720d30ae465cf62fb31c33303b707a18c2ca.f053011abe74ca660c2d98de8747ad0d6a6f401ccfb513e68127b1a46b42ed19"
+	errorMessage := "invalid email and password combination"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findByEmail", email).
+		Return(&model.User{Password: hashedPassword}, nil)
+
+	s := service{repository: repository}
+
+	user, err := s.SignIn(email, password)
+	require.Error(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, user == nil, true)
+	assert.Equal(t, errorMessage, err.Error())
+}
+
+func Test_service_SignIn_NotFound(t *testing.T) {
+	email := "email"
+	password := "password"
+	errorMessage := "invalid email and password combination"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findByEmail", email).
+		Return(nil, errdef.NewNotFound(errors.New(errorMessage)))
+
+	s := service{repository: repository}
+
+	user, err := s.SignIn(email, password)
+	require.Error(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, user == nil, true)
+	assert.Equal(t, errorMessage, err.Error())
+}
+
+func Test_service_FindById_Happy(t *testing.T) {
+	id := uint(1)
+	email := "email"
+	password := "password"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findById", id).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: password,
+		}, nil)
+
+	s := service{repository: repository}
+
+	user, err := s.FindById(id)
+	require.NoError(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, password, user.Password)
+}
+
+func Test_service_FindById_NotFound(t *testing.T) {
+	id := uint(1)
+	errorMessage := "not found"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findById", id).
+		Return(nil, errdef.NewNotFound(errors.New(errorMessage)))
+
+	s := service{repository: repository}
+
+	user, err := s.FindById(id)
+	require.Error(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, user == nil, true)
+	assert.Equal(t, errorMessage, err.Error())
+}
+
+func Test_service_FindOrCreate_Happy(t *testing.T) {
+	id := uint(1)
+	email := "email"
+	password := "password"
+
+	repository := &mockUserRepository{}
+	repository.
+		On("findOrCreate", mock.AnythingOfType("*model.User")).
+		Return(&model.User{
+			Model:    gorm.Model{ID: id},
+			Email:    email,
+			Password: password,
+		}, nil)
+
+	s := service{repository: repository}
+
+	user, err := s.FindOrCreate(email, password)
+	require.NoError(t, err)
+
+	repository.AssertExpectations(t)
+
+	assert.Equal(t, id, user.ID)
+	assert.Equal(t, email, user.Email)
+	assert.Equal(t, password, user.Password)
+}
+
+type mockUserRepository struct {
+	mock.Mock
+}
+
+func (r *mockUserRepository) create(user *model.User) error {
+	args := r.Called(user)
+	err := args.Error(0)
+	return err
+}
+
+func (r *mockUserRepository) findByEmail(email string) (*model.User, error) {
+	args := r.Called(email)
+	user, ok := args.Get(0).(*model.User)
+	if ok {
+		return user, nil
+	} else {
+		return nil, errdef.NewNotFound(errors.New(""))
+	}
+}
+
+func (r *mockUserRepository) findById(id uint) (*model.User, error) {
+	args := r.Called(id)
+	user, ok := args.Get(0).(*model.User)
+	if ok {
+		return user, nil
+	} else {
+		return nil, errdef.NewNotFound(errors.New("not found"))
+	}
+}
+
+func (r *mockUserRepository) findOrCreate(email *model.User) (*model.User, error) {
+	args := r.Called(email)
+	user, ok := args.Get(0).(*model.User)
+	if ok {
+		return user, nil
+	} else {
+		return nil, errdef.NewNotFound(errors.New(""))
+	}
+}


### PR DESCRIPTION
This PR contains initial tests for the user service, handler and the basic auth middleware.

The testing is mostly of happy path and the idea is that once feedback has been collected the test coverage will expand.

The tests can be run, as usually, using `make test`. However this PR also introduces a new docker compose service called `test-coverage` which can be invoked using the make target of the same name. Successful execution of this will leave two files in the root of the project. Namely coverage.html and coverage.out.
